### PR TITLE
NETC-62 Prevents proxyCallbackUrl from being rewritten by default configuration

### DIFF
--- a/DotNetCasClient/Utils/UrlUtil.cs
+++ b/DotNetCasClient/Utils/UrlUtil.cs
@@ -183,8 +183,8 @@ namespace DotNetCasClient.Utils
             else
             {
                 ub = new EnhancedUriBuilder(CasAuthentication.ServerName);
+                ub.Path = request.Url.AbsolutePath;
             }
-            ub.Path = request.Url.AbsolutePath;
             ub.QueryItems.Add(request.QueryString);
             ub.QueryItems.Remove(CasAuthentication.TicketValidator.ArtifactParameterName);
 


### PR DESCRIPTION
When specifying an explicit proxyCallbackUrl in Web.config:

`https://app.example.com/Account/ProxyCallbackUrl?proxyResponse=true`

The base path should have been `/Account/ProxyCallbackUrl` but instead was being rewritten as `/Account/CurrentMethod` where `CurrentMethod` could be any route the client is currently browsing. The corresponding error in cas.log then becomes:

`InvalidProxyChainTicketValidationException: Invalid proxy chain: [https://app.example.com/Account/CurrentMethod?proxyResponse=true]`

The proposed file change effectively "scopes" the setting of the base path when and only when no CasAuthentication.CasProxyCallbackUrl has been specified and resolves the issue:

`[org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter] - Successfully authenticated user: jdoe`