### PR TITLE
Fixing redirection loop bug

### DIFF
--- a/DotNetCasClient/Validation/TicketValidator/Cas20ServiceTicketValidator.cs
+++ b/DotNetCasClient/Validation/TicketValidator/Cas20ServiceTicketValidator.cs
@@ -118,8 +118,9 @@ namespace DotNetCasClient.Validation.TicketValidator
 
                 if (CasAuthentication.ProxyTicketManager != null && !string.IsNullOrEmpty(proxyGrantingTicketIou))
                 {
-                    string proxyGrantingTicket = CasAuthentication.ProxyTicketManager.GetProxyGrantingTicket(proxyGrantingTicketIou);                    
-                    CasAuthentication.ProxyTicketManager.InsertProxyGrantingTicketMapping(proxyGrantingTicketIou, proxyGrantingTicket);
+                    string proxyGrantingTicket = CasAuthentication.ProxyTicketManager.GetProxyGrantingTicket(proxyGrantingTicketIou);
+                    if ( proxyGrantingTicket != null )
+                        CasAuthentication.ProxyTicketManager.InsertProxyGrantingTicketMapping( proxyGrantingTicketIou, proxyGrantingTicket );
                 }
 
                 if (authSuccessResponse.Proxies != null && authSuccessResponse.Proxies.Length > 0)


### PR DESCRIPTION
The proxyGrantingTicket can be null if the cache is expired. When the
proxyGrantingTicket is null and calling InsertProxyGrantingTicketMapping
will throw exception and causing redirection loop.