### PR TITLE
In DotNetCasClient.csproj on LOC 271, removed an ItemGroup

### DIFF
--- a/DotNetCasClient/DotNetCasClient.csproj
+++ b/DotNetCasClient/DotNetCasClient.csproj
@@ -268,11 +268,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="lib\log4net.dll" />
-    <Content Include="LICENSE.txt" />
-    <Content Include="NOTICE.txt" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Very minor change related to the issue I opened recently Missing legacy files #29.  
In DotNetCasClient.csproj on LOC 271, removed an ItemGroup pointing to legacy, removed files.  

      <ItemGroup>
        <Content Include="lib\log4net.dll" />
        <Content Include="LICENSE.txt" />
        <Content Include="NOTICE.txt" />
      </ItemGroup>