### PR TITLE
Add public SignOut method to CasAuthentication class

### DIFF
--- a/DotNetCasClient/CasAuthentication.cs
+++ b/DotNetCasClient/CasAuthentication.cs
@@ -698,6 +698,23 @@ namespace DotNetCasClient
                 response.Redirect(singleSignOutRedirectUrl, true);
             }
         }
+        
+        /// <summary>
+        /// Clear authentication cookie and revoke service ticket in cache.
+        /// </summary>
+        /// <param name="ticket">Optionally specifies FormsAuthenticationTicket to explicitly sign out</param>
+        public static void SignOut(FormsAuthenticationTicket ticket = null)
+        {
+            // Defaults to current ticket
+            if (ticket == null)
+                ticket = GetFormsAuthenticationTicket();
+
+            // ClearAuthCookie();
+            FormsAuthentication.SignOut();
+
+            if (ServiceTicketManager != null && ticket != null)
+                ServiceTicketManager.RevokeTicket(ticket.UserData);
+        }
 
         /// <summary>
         /// Process SingleSignOut requests originating from another web application by removing the ticket 
@@ -889,8 +906,7 @@ namespace DotNetCasClient
                             securityLogger.Warn("CasAuthenticationTicket failed verification: " + casTicket);
 
                             // Deletes the invalid FormsAuthentication cookie from the client.
-                            ClearAuthCookie();
-                            ServiceTicketManager.RevokeTicket(serviceTicket);
+                            SignOut(formsAuthenticationTicket);
 
                             // Don't give this request a User/Principal.  Remove it if it was created
                             // by the underlying FormsAuthenticationModule or another module.


### PR DESCRIPTION
By default, [Request Validation in ASP.NET](https://msdn.microsoft.com/en-us/library/hh882339(v=vs.110).aspx) kicks in upon receiving a single sign-out request from CAS due to the nature of its POSTed content (i.e. XML).

This pull requests provides utility for developers to call `CasAuthentication.SignOut();` which will not only invoke `FormsAuthentication.SignOut` (as a native replacement to `ClearAuthCookies()`) but also clear the user's service ticket from cache, which is currently not being done.